### PR TITLE
Fixed links on for hourly files

### DIFF
--- a/data.html
+++ b/data.html
@@ -179,11 +179,14 @@
 								<a href="https://s3.amazonaws.com/net-zero/2015-data-files/DHW-minute.csv"><div class="button_div mobile_grey_out">CSV</div></a>
 							</td>
 
+
 							<td class="col_not_mobile minute_file_size_td">291 MB</td>
 
 							<td class="download_button col_not_mobile">		
-								<a href="https://s3.amazonaws.com/nist-netzero/2015-data-files/DHW-hour.csv"><div class="button_div">CSV</div></a>
+								<a href="https://s3.amazonaws.com/net-zero/2015-data-files/DHW-hour.csv"><div class="button_div">CSV</div></a>
 							</td>
+
+							https://s3.amazonaws.com/net-zero/2015-data-files/DHW-hour.csv
 
 							<td class="col_not_mobile hour_file_size_td">5.5 MB</td>
 							
@@ -202,7 +205,7 @@
 							<td class="col_not_mobile minute_file_size_td">52 MB</td>
 
 							<td class="download_button col_not_mobile">		
-								<a href="https://s3.amazonaws.com/nist-netzero/2015-data-files/SHW-hour.csv"><div class="button_div">CSV</div></a>
+								<a href="https://s3.amazonaws.com/net-zero/2015-data-files/SHW-hour.csv"><div class="button_div">CSV</div></a>
 							</td>
 
 							<td class="col_not_mobile hour_file_size_td">830.3 KB</td>
@@ -222,7 +225,7 @@
 							<td class="col_not_mobile minute_file_size_td">241 MB</td>
 
 							<td class="download_button col_not_mobile">		
-								<a href="https://s3.amazonaws.com/nist-netzero/2015-data-files/Load-hour.csv"><div class="button_div">CSV</div></a>
+								<a href="https://s3.amazonaws.com/net-zero/2015-data-files/Load-hour.csv"><div class="button_div">CSV</div></a>
 							</td>
 
 							<td class="col_not_mobile hour">4.6 MB</td>
@@ -242,7 +245,7 @@
 							<td class="col_not_mobile minute_file_size_td">64.3 MB</td>
 
 							<td class="download_button col_not_mobile">		
-								<a href="https://s3.amazonaws.com/nist-netzero/2015-data-files/HVAC-hour.csv"><div class="button_div">CSV</div></a>
+								<a href="https://s3.amazonaws.com/net-zero/2015-data-files/HVAC-hour.csv"><div class="button_div">CSV</div></a>
 							</td>
 
 							<td class="col_not_mobile hour_file_size_td">1.3 MB</td>
@@ -262,7 +265,7 @@
 							<td class="col_not_mobile minute_file_size_td">269.5 MB</td>
 
 							<td class="download_button col_not_mobile">		
-								<a href="https://s3.amazonaws.com/nist-netzero/2015-data-files/IndEnv-hour.csv"><div class="button_div">CSV</div></a>
+								<a href="https://s3.amazonaws.com/net-zero/2015-data-files/IndEnv-hour.csv"><div class="button_div">CSV</div></a>
 							</td>
 
 							<td class="col_not_mobile hour_file_size_td">5.1 MB</td>
@@ -282,7 +285,7 @@
 							<td class="col_not_mobile minute_file_size_td">217.7 MB</td>
 
 							<td class="download_button col_not_mobile">		
-								<a href="https://s3.amazonaws.com/nist-netzero/2015-data-files/PV-hour.csv"><div class="button_div">CSV</div></a>
+								<a href="https://s3.amazonaws.com/net-zero/2015-data-files/PV-hour.csv"><div class="button_div">CSV</div></a>
 							</td>
 
 							<td class="col_not_mobile hour_file_size_td">4.1 MB</td>
@@ -302,7 +305,7 @@
 							<td class="col_not_mobile minute_file_size_td">29.1 MB</td>
 
 							<td class="download_button col_not_mobile">		
-								<a href="https://s3.amazonaws.com/nist-netzero/2015-data-files/OutEnv-hour.csv"><div class="button_div">CSV</div></a>
+								<a href="https://s3.amazonaws.com/net-zero/2015-data-files/OutEnv-hour.csv"><div class="button_div">CSV</div></a>
 							</td>
 
 							<td class="col_not_mobile hour_file_size_td">539.3 KB</td>
@@ -322,7 +325,7 @@
 							<td class="col_not_mobile minute_file_size_td">109.4 MB</td>
 
 							<td class="download_button col_not_mobile">		
-								<a href="https://s3.amazonaws.com/nist-netzero/2015-data-files/Vent-hour.csv"><div class="button_div">CSV</div></a>
+								<a href="https://s3.amazonaws.com/net-zero/2015-data-files/Vent-hour.csv"><div class="button_div">CSV</div></a>
 							</td>
 
 							<td class="col_not_mobile hour_file_size_td">1.9 MB</td>
@@ -342,7 +345,7 @@
 							<td class="col_not_mobile minute_file_size_td">500.5 MB</td>
 
 							<td class="download_button col_not_mobile">		
-								<a href="https://s3.amazonaws.com/nist-netzero/2015-data-files/Elec-hour.csv"><div class="button_div">CSV</div></a>
+								<a href="https://s3.amazonaws.com/net-zero/2015-data-files/Elec-hour.csv"><div class="button_div">CSV</div></a>
 							</td>
 
 							<td class="col_not_mobile hour_file_size_td">9 MB</td>
@@ -362,7 +365,7 @@
 							<td class="col_not_mobile minute_file_size_td">32.1 MB</td>
 
 							<td class="download_button col_not_mobile">		
-								<a href="https://s3.amazonaws.com/nist-netzero/2015-data-files/Misc-hour.csv"><div class="button_div">CSV</div></a>
+								<a href="https://s3.amazonaws.com/net-zero/2015-data-files/Misc-hour.csv"><div class="button_div">CSV</div></a>
 							</td>
 
 							<td class="col_not_mobile hour_file_size_td">221.8 KB</td>
@@ -382,7 +385,7 @@
 							<td class="col_not_mobile minute_file_size_td">67.1 KB</td>
 
 							<td class="download_button col_not_mobile">		
-								<a href="https://s3.amazonaws.com/nist-netzero/2015-data-files/Metadata-hour.csv"><div class="button_div">CSV</div></a>
+								<a href="https://s3.amazonaws.com/net-zero/2015-data-files/Metadata-hour.csv"><div class="button_div">CSV</div></a>
 							</td>
 
 							<td class="col_not_mobile hour_file_size_td">67.1 KB</td>
@@ -402,7 +405,7 @@
 							<td class="col_not_mobile minute_file_size_td">1.6 GB</td>
 
 							<td class="download_button col_not_mobile">		
-								<a href="https://s3.amazonaws.com/nist-netzero/2015-data-files/All-Subsystems-hour.csv"><div class="button_div">CSV</div></a>
+								<a href="https://s3.amazonaws.com/net-zero/2015-data-files/All-Subsystems-hour.csv"><div class="button_div">CSV</div></a>
 							</td>
 
 							<td class="col_not_mobile hour_file_size_td">31.9 MB</td>


### PR DESCRIPTION
Changed 'nist-netzero' back to 'net-zero' since the hourly files
aren't currently in the NIST bucket since we just made them.